### PR TITLE
Atomic withdraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Now you have the default `Store` methods available!
 - `Store.delete_all/0` Delete all records stored
 - `Store.one/1` Get one record matching either an attributes search or `match` query
 - `Store.select/1` Get all records matching either an attributes search or `match` query
-- `Store.withdraw/1` Get one record matching either an attributes search or `match` query, delete the record and return it
+- `Store.withdraw/1` Atomically get one record matching either an attributes search or `match` query, delete the record and return it. The find-and-delete is a single atomic operation (`:ets.select_delete/2` for ETS, a `:mnesia.transaction/1` for Mnesia), so under concurrent access exactly one caller receives `{:ok, record}` for a given record and any others receive `{:error, :not_found}`. This makes `withdraw/1` safe for take-once workloads such as one time use tokens.
 - `Store.write/1` Write a record into the memmory table
 
 ## Query interface
@@ -141,7 +141,7 @@ by adding `active_memory` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:active_memory, "~> 0.2.1"}
+    {:active_memory, "~> 0.4.0"}
   ]
 end
 ```
@@ -155,7 +155,7 @@ There are many reasons to be leveraging the power of in memory store and the awe
 Instead of having hard coded secrets and application settings crowding your config files store them in an in memory table. Provide your application a small UI to support the secrets and settings and you can update while the application is running in a matter of seconds.
 
 ### One Time Use Tokens 
-Perfect for short lived tokens such as password reset tokens, 2FA tokens, magic links (password less login) etc. Store the tokens along with any other needed data into an `ActiveMemory.Store` to reduce the burden of your database and provide your users a better experience with faster responses.
+Perfect for short lived tokens such as password reset tokens, 2FA tokens, magic links (password less login) etc. Store the tokens along with any other needed data into an `ActiveMemory.Store` to reduce the burden of your database and provide your users a better experience with faster responses. Use `Store.withdraw/1` to redeem a token: it atomically fetches and deletes the record, so even under concurrent requests a token can only be redeemed once.
 
 ### API Keys for clients
 For applications which have a fixed set of API Keys or a relativly small set of API keys (less than a few thousand). Store the keys along with any relevent information into an `ActiveMemory.Store` to reduce the burden of your database and provide your users a better experience with faster responses.

--- a/lib/adapters/adapter.ex
+++ b/lib/adapters/adapter.ex
@@ -17,5 +17,9 @@ defmodule ActiveMemory.Adapters.Adapter do
 
   @callback select(list(any()), atom()) :: {:ok, list(map())} | {:error, any()}
 
+  @callback withdraw(map(), atom()) :: {:ok, map()} | {:error, any()}
+
+  @callback withdraw(list(any()), atom()) :: {:ok, map()} | {:error, any()}
+
   @callback write(map(), atom()) :: {:ok, map()} | {:error, any()}
 end

--- a/lib/adapters/ets.ex
+++ b/lib/adapters/ets.ex
@@ -154,6 +154,29 @@ defmodule ActiveMemory.Adapters.Ets do
   end
 
   @doc """
+  Atomically find a single struct matching the query, delete it, and return it.
+
+  The delete is performed with `:ets.select_delete/2`, so the find-and-remove is a
+  single atomic ETS operation. Under concurrent access exactly one caller receives
+  `{:ok, struct}` for a given record; any others receive `{:error, :not_found}`.
+  ```elixir
+    iex:> DogStore.withdraw(%{name: "gem", breed: "Shaggy Black Lab"})
+    {:ok, %Dog{}}
+  ```
+  """
+  @spec withdraw(map() | tuple(), atom()) :: {:ok, map()} | {:error, any()}
+  def withdraw(query, table) do
+    with {:ok, struct} <- one(query, table),
+         ets_tuple <- to_tuple(struct),
+         count when count >= 1 <- :ets.select_delete(table, [{ets_tuple, [], [true]}]) do
+      {:ok, struct}
+    else
+      0 -> {:error, :not_found}
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  @doc """
   Save a struct to a table.
   ```elixir
     iex:> DogStore.write(%Dog{name: "gem", breed: "Shaggy Black Lab"})

--- a/lib/adapters/mnesia.ex
+++ b/lib/adapters/mnesia.ex
@@ -171,6 +171,40 @@ defmodule ActiveMemory.Adapters.Mnesia do
   end
 
   @doc """
+  Atomically find a single struct matching the query, delete it, and return it.
+
+  The find and delete run inside a single `:mnesia.transaction/1`, so under
+  concurrent access exactly one caller receives `{:ok, struct}` for a given record;
+  any others receive `{:error, :not_found}`.
+  ```elixir
+    iex:> DogStore.withdraw(%{name: "gem", breed: "Shaggy Black Lab"})
+    {:ok, %Dog{}}
+  ```
+  """
+  @spec withdraw(map() | tuple(), atom()) :: {:ok, map()} | {:error, any()}
+  def withdraw(query_map, table) when is_map(query_map) do
+    with {:ok, query} <- MatchGuards.build(table, query_map),
+         match_query <- Tuple.insert_at(query, 0, table),
+         {:atomic, {:ok, record}} <- withdraw_match_object(match_query, table) do
+      {:ok, to_struct(record, table)}
+    else
+      {:atomic, {:error, message}} -> {:error, message}
+      {:error, message} -> {:error, message}
+      {:aborted, message} -> {:error, message}
+    end
+  end
+
+  def withdraw(query, table) when is_tuple(query) do
+    with match_spec <- build_mnesia_match_spec(query, table),
+         {:atomic, {:ok, record}} <- withdraw_select_object(match_spec, table) do
+      {:ok, to_struct(record, table)}
+    else
+      {:atomic, {:error, message}} -> {:error, message}
+      {:aborted, message} -> {:error, message}
+    end
+  end
+
+  @doc """
   Save a struct to a table.
   ```elixir
     iex:> DogStore.write(%Dog{name: "gem", breed: "Shaggy Black Lab"})
@@ -203,11 +237,33 @@ defmodule ActiveMemory.Adapters.Mnesia do
     end)
   end
 
+  defp withdraw_match_object(match_query, table) do
+    :mnesia.transaction(fn ->
+      delete_matched(:mnesia.match_object(table, match_query, :write), table)
+    end)
+  end
+
+  defp withdraw_select_object(match_spec, table) do
+    :mnesia.transaction(fn ->
+      delete_matched(:mnesia.select(table, match_spec, :read), table)
+    end)
+  end
+
   defp write_object(object, table) do
     :mnesia.transaction(fn ->
       :mnesia.write(table, object, :write)
     end)
   end
+
+  defp delete_matched([record], table) do
+    :ok = :mnesia.delete_object(table, record, :write)
+    {:ok, record}
+  end
+
+  defp delete_matched([], _table), do: {:error, :not_found}
+
+  defp delete_matched(records, _table) when is_list(records),
+    do: {:error, :more_than_one_result}
 
   defp build_mnesia_match_spec(query, table) do
     query_map = :erlang.apply(table, :__attributes__, [:query_map])

--- a/lib/store.ex
+++ b/lib/store.ex
@@ -124,12 +124,7 @@ defmodule ActiveMemory.Store do
 
       @spec withdraw(map() | list(any())) :: {:ok, map()} | {:error, any()}
       def withdraw(query) do
-        with {:ok, %{} = record} <- one(query),
-             :ok <- delete(record) do
-          {:ok, record}
-        else
-          {:error, message} -> {:error, message}
-        end
+        :erlang.apply(@table.__attributes__(:adapter), :withdraw, [query, @table])
       end
 
       @spec write(map()) :: {:ok, map()} | {:error, any()}

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ActiveMemory.MixProject do
   @github "https://github.com/SullysMustyRuby/active_memory"
   @license "MIT"
   @name "ActiveMemory"
-  @version "0.3.3"
+  @version "0.4.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,12 @@ defmodule ActiveMemory.MixProject do
       deps: deps(),
       package: package(),
 
+      # Support modules and seed files under test/support are loaded manually by
+      # test/test_helper.exs, so exclude them from the Elixir 1.19+ test file scan.
+      test_ignore_filters: [
+        ~r"^test/support/"
+      ],
+
       # ExDoc
       name: @name,
       source_url: @github,

--- a/test/adapters/ets_test.exs
+++ b/test/adapters/ets_test.exs
@@ -333,6 +333,25 @@ defmodule ActiveMemory.Adapters.EtsTest do
     end
   end
 
+  describe "withdraw/1 is atomic under concurrency" do
+    test "only one concurrent caller withdraws a given record" do
+      {:ok, _record} = DogStore.write(%Dog{name: "atomic", breed: "TestHound"})
+      query = %{name: "atomic", breed: "TestHound"}
+
+      results =
+        1..20
+        |> Task.async_stream(fn _ -> DogStore.withdraw(query) end,
+          max_concurrency: 20,
+          ordered: false
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.count(results, &match?({:ok, _}, &1)) == 1
+      assert Enum.count(results, &(&1 == {:error, :not_found})) == 19
+      assert DogStore.one(query) == {:error, :not_found}
+    end
+  end
+
   describe "write/1" do
     test "writes the record with the correct schema" do
       record = %Dog{

--- a/test/adapters/mnesia_test.exs
+++ b/test/adapters/mnesia_test.exs
@@ -331,6 +331,35 @@ defmodule ActiveMemory.Adapters.MneisaTest do
     end
   end
 
+  describe "withdraw/1 is atomic under concurrency" do
+    setup do
+      on_exit(fn -> :mnesia.clear_table(Person) end)
+
+      :ok
+    end
+
+    test "only one concurrent caller withdraws a given record" do
+      :mnesia.clear_table(Person)
+
+      {:ok, _record} =
+        PeopleStore.write(%Person{first: "atomic", last: "tester", email: "atomic@test.com"})
+
+      query = %{first: "atomic", last: "tester"}
+
+      results =
+        1..20
+        |> Task.async_stream(fn _ -> PeopleStore.withdraw(query) end,
+          max_concurrency: 20,
+          ordered: false
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.count(results, &match?({:ok, _}, &1)) == 1
+      assert Enum.count(results, &(&1 == {:error, :not_found})) == 19
+      assert PeopleStore.one(query) == {:error, :not_found}
+    end
+  end
+
   describe "write/1" do
     setup do
       on_exit(fn -> :mnesia.clear_table(Person) end)


### PR DESCRIPTION
Updated the `withdraw` functions to ensure they are atomic. Also fixed warnings Elixir 1.19+ introduced.