### PR TITLE
Normalize delete_all to return :ok on success

### DIFF
--- a/lib/adapters/adapter.ex
+++ b/lib/adapters/adapter.ex
@@ -7,7 +7,7 @@ defmodule ActiveMemory.Adapters.Adapter do
 
   @callback delete(map(), atom()) :: :ok | {:error, any()}
 
-  @callback delete_all(atom()) :: true | any()
+  @callback delete_all(atom()) :: :ok | {:error, any()}
 
   @callback one(map(), atom()) :: {:ok, map()} | {:error, any()}
 

--- a/lib/adapters/ets.ex
+++ b/lib/adapters/ets.ex
@@ -74,12 +74,13 @@ defmodule ActiveMemory.Adapters.Ets do
   Delete all structs from a table.
   ```elixir
     iex:> PeopleStore.delete_all(Person)
-    true
+    :ok
   ```
   """
-  @spec delete_all(atom()) :: true | any()
+  @spec delete_all(atom()) :: :ok
   def delete_all(table) do
-    :ets.delete_all_objects(table)
+    true = :ets.delete_all_objects(table)
+    :ok
   end
 
   @doc """

--- a/lib/adapters/mnesia.ex
+++ b/lib/adapters/mnesia.ex
@@ -94,12 +94,15 @@ defmodule ActiveMemory.Adapters.Mnesia do
   Delete all structs from a table.
   ```elixir
     iex:> PeopleStore.delete_all(Person)
-    true
+    :ok
   ```
   """
-  @spec delete_all(atom()) :: true | any()
+  @spec delete_all(atom()) :: :ok | {:error, any()}
   def delete_all(table) do
-    :mnesia.clear_table(table)
+    case :mnesia.clear_table(table) do
+      {:atomic, :ok} -> :ok
+      {:aborted, message} -> {:error, message}
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ActiveMemory.MixProject do
   @github "https://github.com/SullysMustyRuby/active_memory"
   @license "MIT"
   @name "ActiveMemory"
-  @version "0.7.1"
+  @version "0.7.2"
 
   def project do
     [

--- a/test/active_repo_test.exs
+++ b/test/active_repo_test.exs
@@ -203,10 +203,15 @@ defmodule ActiveMemory.ActiveRepoTest do
       {:ok, _record} = MultiRepo.write(%Widget{name: "x", color: "blue"})
       {:ok, _record} = MultiRepo.write(%Gadget{name: "y", category: "z"})
 
-      MultiRepo.delete_all(Widget)
+      assert MultiRepo.delete_all(Widget) == :ok
 
       assert MultiRepo.all(Widget) == []
       assert length(MultiRepo.all(Gadget)) == 1
+    end
+
+    test "delete_all returns :ok for both ets and mnesia tables" do
+      assert MultiRepo.delete_all(Widget) == :ok
+      assert MultiRepo.delete_all(Gadget) == :ok
     end
   end
 

--- a/test/adapters/ets_test.exs
+++ b/test/adapters/ets_test.exs
@@ -83,12 +83,13 @@ defmodule ActiveMemory.Adapters.EtsTest do
   end
 
   describe "delete_all/1" do
-    test "with a valid table with items will delete all items" do
+    test "with a valid table with items returns :ok and deletes all items" do
       write_seeds()
       dogs = DogStore.all()
 
       assert length(dogs) == 10
-      assert DogStore.delete_all()
+      assert DogStore.delete_all() == :ok
+      assert DogStore.all() == []
     end
   end
 

--- a/test/adapters/mnesia_test.exs
+++ b/test/adapters/mnesia_test.exs
@@ -78,6 +78,24 @@ defmodule ActiveMemory.Adapters.MneisaTest do
     end
   end
 
+  describe "delete_all/0" do
+    setup do
+      write_seeds()
+
+      on_exit(fn -> :mnesia.clear_table(Person) end)
+
+      :ok
+    end
+
+    test "returns :ok and deletes all items" do
+      people = PeopleStore.all()
+
+      assert length(people) == 10
+      assert PeopleStore.delete_all() == :ok
+      assert PeopleStore.all() == []
+    end
+  end
+
   describe "one/1 with a map query" do
     setup do
       write_seeds()

--- a/test/store_test.exs
+++ b/test/store_test.exs
@@ -71,7 +71,7 @@ defmodule ActiveMemory.StoreTest do
     test "repopulates the store from the seed file" do
       {:ok, pid} = PeopleStore.start_link()
 
-      PeopleStore.delete_all()
+      assert PeopleStore.delete_all() == :ok
       assert PeopleStore.all() == []
 
       assert PeopleStore.reload_seeds() == {:ok, :seed_success}


### PR DESCRIPTION
Store.delete_all/0 and ActiveRepo.delete_all/1 are specced to return :ok | {:error, any()}, but the adapters leaked their raw backend results: the ETS adapter returned true from :ets.delete_all_objects/1 and the Mnesia adapter returned {:atomic, :ok} from :mnesia.clear_table/1. Callers matching the documented spec with :ok = Store.delete_all() raised a MatchError.

Both adapters now return :ok on success, with the Mnesia adapter translating {:aborted, message} to {:error, message} as delete/2 already does. The Adapter behaviour callback spec is updated to match, and tests assert the return value on ETS and Mnesia stores and through ActiveRepo.