### PR TITLE
Fix ttl type warning

### DIFF
--- a/lib/active_repo.ex
+++ b/lib/active_repo.ex
@@ -99,6 +99,7 @@ defmodule ActiveMemory.ActiveRepo do
                      table -> {table, []}
                    end)
       @tables Enum.map(@repo_tables, fn {table, _opts} -> table end)
+      @ttl_tables Enum.filter(@tables, fn table -> table.__attributes__(:ttl) end)
       @initial_state Keyword.get(opts, :initial_state, :default)
       @sweep_interval Keyword.get(opts, :sweep_interval, unquote(@default_sweep_interval))
 
@@ -184,12 +185,7 @@ defmodule ActiveMemory.ActiveRepo do
       def handle_info(:sweep, state) do
         now = System.system_time(:millisecond)
 
-        Enum.each(@repo_tables, fn {table, _opts} ->
-          case table.__attributes__(:ttl) do
-            nil -> :ok
-            _ttl -> Operations.delete_expired(table, now)
-          end
-        end)
+        Enum.each(@ttl_tables, fn table -> Operations.delete_expired(table, now) end)
 
         __schedule_sweep__()
         {:noreply, state}
@@ -219,10 +215,13 @@ defmodule ActiveMemory.ActiveRepo do
       defp __maybe_seed__(:created, seed_file, table), do: Operations.seed(seed_file, table)
 
       # Schedules the next expiry sweep only when at least one table uses a `ttl`.
-      defp __schedule_sweep__ do
-        case Enum.any?(@tables, fn table -> table.__attributes__(:ttl) end) do
-          true -> Process.send_after(self(), :sweep, @sweep_interval)
-          false -> :ok
+      # Only the clause matching the compile-time table configuration is generated
+      # so the Elixir 1.19+ type checker never sees an unreachable clause.
+      if @ttl_tables == [] do
+        defp __schedule_sweep__, do: :ok
+      else
+        defp __schedule_sweep__ do
+          Process.send_after(self(), :sweep, @sweep_interval)
         end
       end
 

--- a/lib/adapters/ets.ex
+++ b/lib/adapters/ets.ex
@@ -133,22 +133,19 @@ defmodule ActiveMemory.Adapters.Ets do
   """
   @spec select(map() | tuple(), atom()) :: {:ok, list(map())} | {:error, any()}
   def select(query_map, table) when is_map(query_map) do
-    with {:ok, query} <- MatchGuards.build(table, query_map),
-         records when is_list(records) <- match_query(query, table) do
-      {:ok, to_struct(records, table)}
-    else
-      [] -> {:ok, []}
-      {:error, message} -> {:error, message}
+    case MatchGuards.build(table, query_map) do
+      {:ok, query} ->
+        records = match_query(query, table)
+        {:ok, to_struct(records, table)}
+
+      {:error, message} ->
+        {:error, message}
     end
   end
 
   def select(query, table) when is_tuple(query) do
-    with records when is_list(records) <- select_query(query, table) do
-      {:ok, to_struct(records, table)}
-    else
-      [] -> {:ok, []}
-      {:error, message} -> {:error, message}
-    end
+    records = select_query(query, table)
+    {:ok, to_struct(records, table)}
   end
 
   @doc """

--- a/lib/store.ex
+++ b/lib/store.ex
@@ -197,11 +197,14 @@ defmodule ActiveMemory.Store do
       defp __maybe_run_seeds__(:created), do: Operations.seed(@seed_file, @table)
 
       # Schedules the next expiry sweep only when the table actually uses a `ttl`.
-      defp __schedule_sweep__ do
-        case @table.__attributes__(:ttl) do
-          nil -> :ok
-          _ttl -> Process.send_after(self(), :sweep, @sweep_interval)
+      # Only the clause matching the table's compile-time `ttl` is generated so the
+      # Elixir 1.19+ type checker never sees an unreachable clause.
+      if @table.__attributes__(:ttl) do
+        defp __schedule_sweep__ do
+          Process.send_after(self(), :sweep, @sweep_interval)
         end
+      else
+        defp __schedule_sweep__, do: :ok
       end
 
       # Only the clause matching the compile-time option is generated so the

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ActiveMemory.MixProject do
   @github "https://github.com/SullysMustyRuby/active_memory"
   @license "MIT"
   @name "ActiveMemory"
-  @version "0.7.2"
+  @version "0.7.3"
 
   def project do
     [


### PR DESCRIPTION
Was seeing a warning on Elixir v 1.20 above about ttl with:
"the following clause cannot match because the previous clauses already matched all possible values:"
There was also a warning on the ETS adapter:
"the following clause will never match:"
This is a fix for those.