### PR TITLE
Point the demo section at current material

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,9 +539,7 @@ Create an `ActiveMemory.Store` to manage your admins easily and safely.
 **and many many many more...**
 
 ## Demo Application
-The following Repo is a demo application using ActiveMemory and MnesiaManager concept.
-- [BeamDemo](https://github.com/SullysMustyRuby/BeamDemo)
-- [MnesiaManager](https://github.com/SullysMustyRuby/ActiveMemoryManager)
+A demo application built on the current release — showing one-time tokens with `withdraw/1` and `ttl`, sessions, and feature flags — is in progress and will be linked here. Until then, the [Coming from Ecto](https://hexdocs.pm/active_memory/coming_from_ecto.html) guide has complete, current examples.
 
 ## Planned Enhancements
 


### PR DESCRIPTION
The Demo Application section linked BeamDemo and ActiveMemoryManager, both untouched since 2022. BeamDemo pins active_memory 0.2.4 and hand rolls what the library now provides — a NotFoundError, changeset casting, lookups by key — so it teaches the pre 0.8.0 API to anyone who follows the link. ActiveMemoryManager is a concept sketch that does not depend on the library at all.

A demo application built on the current release is planned; until it exists the section says so and points at the Coming from Ecto guide, which has complete, current examples.