### PR TITLE
Add mix active_memory.candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to ActiveMemory are documented here. Versions follow
 [Semantic Versioning](https://semver.org); while the package is pre-1.0 a minor
 bump may carry a behavior change, and those are called out below.
 
-## Unreleased
+## 0.8.1
 
 ### Added
 
@@ -13,7 +13,24 @@ bump may carry a behavior change, and those are called out below.
   MySQL/MariaDB via `performance_schema`) and reports each table's read/write
   ratio, row count and size, flagging the high-read, low-write tables that are
   candidates for an ActiveMemory table. Thresholds are tunable with
-  `--min-ratio` and `--max-rows`.
+  `--min-ratio`, `--max-rows` and `--min-reads`, and `--timeout` covers schemas
+  whose statistics views are slow to answer.
+
+  The task does **not** start your application: only its configuration is
+  loaded, and the one repo you name is started with a two connection pool, so
+  it is safe to point at a production database with read-only credentials. It
+  runs only read-only queries against statistics views, never application
+  tables. Known infrastructure tables (job queues, migration bookkeeping) are
+  reported as such rather than as candidates, and tables with too little
+  recorded traffic are not judged at all.
+
+  Validated against PostgreSQL and against a production Aurora MySQL database.
+
+### Changed
+
+- ActiveMemory now requires Elixir 1.15 or later, matching the versions CI
+  tests against. Earlier Elixirs may continue to work but are no longer
+  resolved for or verified.
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to ActiveMemory are documented here. Versions follow
 [Semantic Versioning](https://semver.org); while the package is pre-1.0 a minor
 bump may carry a behavior change, and those are called out below.
 
+## Unreleased
+
+### Added
+
+- `mix active_memory.candidates` — reads table statistics through the
+  application's own Ecto repo (PostgreSQL via `pg_stat_user_tables`,
+  MySQL/MariaDB via `performance_schema`) and reports each table's read/write
+  ratio, row count and size, flagging the high-read, low-write tables that are
+  candidates for an ActiveMemory table. Thresholds are tunable with
+  `--min-ratio` and `--max-rows`.
+
 ## 0.8.0
 
 Ecto compatibility. A `Table` can now be typed or defined as an Ecto schema, and

--- a/README.md
+++ b/README.md
@@ -547,6 +547,23 @@ Applications using JWT's can store the keys in an `ActiveMemory.Store` and provi
 
 **and many many many more...**
 
+### Find the candidates in your own app
+You don't have to guess which tables fit: your database already keeps the numbers. `mix active_memory.candidates` reads them through your application's own Ecto repo (PostgreSQL and MySQL/MariaDB) and reports every table's read/write ratio and size:
+
+```bash
+mix active_memory.candidates
+```
+
+```text
+table    rows   size    reads    writes  ratio    verdict
+----------------------------------------------------------------
+plans    20     32 KB   182,340  14      13024:1  ** strong candidate
+country  249    128 KB  98,220   0       inf      ** strong candidate
+users    98,113 220 MB  530,001  98,200  5.4:1    write heavy
+```
+
+Statistics are cumulative, so run it against a database that has seen production-like traffic. Thresholds are tunable with `--min-ratio` and `--max-rows`; see `mix help active_memory.candidates`.
+
 ## Demo Application
 A demo application built on the current release — showing catalog data served from memory instead of the database, one-time tokens with `withdraw/1` and `ttl`, and feature flags — is in progress and will be linked here. Until then, the [Coming from Ecto](https://hexdocs.pm/active_memory/coming_from_ecto.html) guide has complete, current examples.
 

--- a/lib/candidates.ex
+++ b/lib/candidates.ex
@@ -1,0 +1,218 @@
+defmodule ActiveMemory.Candidates do
+  @moduledoc """
+  Finds database tables whose workload — read constantly, written rarely — makes
+  them candidates for an `ActiveMemory.Table`.
+
+  This is the engine behind `mix active_memory.candidates`, which runs it against
+  the host application's own Ecto repo. The analysis itself is pure, so it can also
+  be fed rows gathered any other way.
+
+  ## The heuristic
+
+  A table is a candidate when its **read/write ratio** is high and it is **small
+  enough** to hold in memory. Reads and writes come from the database's own
+  statistics:
+
+    - PostgreSQL: `pg_stat_user_tables` — reads are scans (`seq_scan + idx_scan`,
+      each query touching the table counts once), writes are rows changed
+      (`n_tup_ins + n_tup_upd + n_tup_del`).
+    - MySQL/MariaDB: `performance_schema.table_io_waits_summary_by_table` — reads
+      are row fetch operations (`COUNT_FETCH`), writes are row change operations
+      (`COUNT_INSERT + COUNT_UPDATE + COUNT_DELETE`).
+
+  The two databases count reads differently (queries vs rows), so ratios are not
+  comparable across databases — only between tables of the same one, which is what
+  matters for finding candidates.
+
+  Statistics are cumulative: since the last statistics reset on PostgreSQL, and
+  since server start on MySQL. Run against a database that has seen
+  production-like traffic, or the ratios describe nothing.
+  """
+
+  defstruct [:table, :rows, :bytes, :reads, :writes, :ratio, :verdict]
+
+  @type t :: %__MODULE__{
+          table: String.t(),
+          rows: non_neg_integer(),
+          bytes: non_neg_integer(),
+          reads: non_neg_integer(),
+          writes: non_neg_integer(),
+          ratio: float() | :infinity,
+          verdict: :strong | :candidate | :too_large | :write_heavy | :no_traffic
+        }
+
+  @default_min_ratio 10
+  @default_max_rows 50_000
+
+  @postgres_sql """
+  SELECT relname,
+         COALESCE(n_live_tup, 0),
+         COALESCE(pg_total_relation_size(relid), 0),
+         COALESCE(seq_scan, 0) + COALESCE(idx_scan, 0),
+         COALESCE(n_tup_ins, 0) + COALESCE(n_tup_upd, 0) + COALESCE(n_tup_del, 0)
+  FROM pg_stat_user_tables
+  ORDER BY 4 DESC
+  """
+
+  @mysql_sql """
+  SELECT io.OBJECT_NAME,
+         COALESCE(t.TABLE_ROWS, 0),
+         COALESCE(t.DATA_LENGTH + t.INDEX_LENGTH, 0),
+         io.COUNT_FETCH,
+         io.COUNT_INSERT + io.COUNT_UPDATE + io.COUNT_DELETE
+  FROM performance_schema.table_io_waits_summary_by_table io
+  LEFT JOIN information_schema.TABLES t
+    ON t.TABLE_SCHEMA = io.OBJECT_SCHEMA AND t.TABLE_NAME = io.OBJECT_NAME
+  WHERE io.OBJECT_SCHEMA = DATABASE()
+  ORDER BY 4 DESC
+  """
+
+  @doc """
+  The statistics query for an Ecto adapter.
+
+  Returns `{:ok, sql}` whose result rows are
+  `[table, row_estimate, total_bytes, reads, writes]`, or `{:error, message}` for
+  an adapter without table-level read/write statistics.
+  """
+  @spec sql_for(module()) :: {:ok, String.t()} | {:error, String.t()}
+  def sql_for(Ecto.Adapters.Postgres), do: {:ok, @postgres_sql}
+
+  def sql_for(Ecto.Adapters.MyXQL), do: {:ok, @mysql_sql}
+
+  def sql_for(adapter) do
+    {:error,
+     "#{inspect(adapter)} is not supported: only PostgreSQL and MySQL/MariaDB expose " <>
+       "the table level read/write statistics this analysis needs."}
+  end
+
+  @doc """
+  Classify raw statistics rows (`[table, rows, bytes, reads, writes]`).
+
+  Options:
+    - `:min_ratio` — reads per write to call a table a candidate
+      (default #{@default_min_ratio}; ten times that is a strong candidate)
+    - `:max_rows` — above this a table is `:too_large` for the in-memory sweet
+      spot regardless of its ratio (default #{@default_max_rows})
+
+  Results are sorted candidates first, then by reads.
+  """
+  @spec analyze(list(list()), keyword()) :: list(t())
+  def analyze(rows, opts \\ []) do
+    min_ratio = Keyword.get(opts, :min_ratio, @default_min_ratio)
+    max_rows = Keyword.get(opts, :max_rows, @default_max_rows)
+
+    rows
+    |> Enum.map(fn [table, row_count, bytes, reads, writes] ->
+      ratio = ratio(reads, writes)
+
+      %__MODULE__{
+        table: to_string(table),
+        rows: row_count,
+        bytes: bytes,
+        reads: reads,
+        writes: writes,
+        ratio: ratio,
+        verdict: verdict(ratio, row_count, reads, writes, min_ratio, max_rows)
+      }
+    end)
+    |> Enum.sort_by(fn %{verdict: verdict, reads: reads} -> {rank(verdict), -reads} end)
+  end
+
+  @doc """
+  Render analyzed results as a text report.
+  """
+  @spec render(list(t())) :: String.t()
+  def render([]), do: "No user tables with statistics found.\n"
+
+  def render(results) do
+    headers = ["table", "rows", "size", "reads", "writes", "ratio", "verdict"]
+
+    rows =
+      Enum.map(results, fn result ->
+        [
+          result.table,
+          format_count(result.rows),
+          format_bytes(result.bytes),
+          format_count(result.reads),
+          format_count(result.writes),
+          format_ratio(result.ratio),
+          label(result.verdict)
+        ]
+      end)
+
+    widths =
+      [headers | rows]
+      |> Enum.zip_with(fn column -> column |> Enum.map(&String.length/1) |> Enum.max() end)
+
+    line = fn cells ->
+      cells
+      |> Enum.zip_with(widths, &String.pad_trailing/2)
+      |> Enum.join("  ")
+      |> String.trim_trailing()
+    end
+
+    candidates = Enum.count(results, &(&1.verdict in [:strong, :candidate]))
+
+    summary =
+      case candidates do
+        0 -> "No candidates found with the current thresholds."
+        1 -> "1 candidate for ActiveMemory."
+        n -> "#{n} candidates for ActiveMemory."
+      end
+
+    Enum.join(
+      [line.(headers), String.duplicate("-", Enum.sum(widths) + 2 * (length(widths) - 1))] ++
+        Enum.map(rows, line) ++ ["", summary],
+      "\n"
+    ) <> "\n"
+  end
+
+  defp ratio(0, _writes), do: 0.0
+  defp ratio(_reads, 0), do: :infinity
+  defp ratio(reads, writes), do: reads / writes
+
+  defp verdict(_ratio, _rows, 0, 0, _min_ratio, _max_rows), do: :no_traffic
+
+  defp verdict(ratio, rows, _reads, _writes, min_ratio, max_rows) do
+    cond do
+      rows > max_rows -> :too_large
+      ratio == :infinity -> :strong
+      ratio >= min_ratio * 10 -> :strong
+      ratio >= min_ratio -> :candidate
+      true -> :write_heavy
+    end
+  end
+
+  defp rank(:strong), do: 0
+  defp rank(:candidate), do: 1
+  defp rank(:too_large), do: 2
+  defp rank(:write_heavy), do: 3
+  defp rank(:no_traffic), do: 4
+
+  defp label(:strong), do: "** strong candidate"
+  defp label(:candidate), do: "*  candidate"
+  defp label(:too_large), do: "too large to pin in memory"
+  defp label(:write_heavy), do: "write heavy"
+  defp label(:no_traffic), do: "no traffic recorded"
+
+  defp format_ratio(:infinity), do: "inf"
+  defp format_ratio(ratio) when ratio >= 100, do: "#{round(ratio)}:1"
+  defp format_ratio(ratio), do: "#{Float.round(ratio * 1.0, 1)}:1"
+
+  defp format_count(count) when count < 1000, do: Integer.to_string(count)
+
+  defp format_count(count) do
+    count
+    |> Integer.to_string()
+    |> String.to_charlist()
+    |> Enum.reverse()
+    |> Enum.chunk_every(3)
+    |> Enum.join(",")
+    |> String.reverse()
+  end
+
+  defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
+  defp format_bytes(bytes) when bytes < 1024 * 1024, do: "#{div(bytes, 1024)} KB"
+  defp format_bytes(bytes) when bytes < 1024 * 1024 * 1024, do: "#{div(bytes, 1024 * 1024)} MB"
+  defp format_bytes(bytes), do: "#{Float.round(bytes / (1024 * 1024 * 1024), 1)} GB"
+end

--- a/lib/candidates.ex
+++ b/lib/candidates.ex
@@ -38,7 +38,8 @@ defmodule ActiveMemory.Candidates do
           reads: non_neg_integer(),
           writes: non_neg_integer(),
           ratio: float() | :infinity,
-          verdict: :strong | :candidate | :too_large | :write_heavy | :no_traffic
+          verdict:
+            :strong | :candidate | :too_large | :write_heavy | :infrastructure | :no_traffic
         }
 
   @default_min_ratio 10
@@ -116,7 +117,7 @@ defmodule ActiveMemory.Candidates do
         reads: reads,
         writes: writes,
         ratio: ratio,
-        verdict: verdict(ratio, row_count, reads, writes, min_ratio, max_rows)
+        verdict: verdict(to_string(table), ratio, row_count, reads, writes, min_ratio, max_rows)
       }
     end)
     |> Enum.sort_by(fn %{verdict: verdict, reads: reads} -> {rank(verdict), -reads} end)
@@ -182,10 +183,18 @@ defmodule ActiveMemory.Candidates do
   defp ratio(_reads, 0), do: :infinity
   defp ratio(reads, writes), do: reads / writes
 
-  defp verdict(_ratio, _rows, 0, 0, _min_ratio, _max_rows), do: :no_traffic
+  # Job queues and migration bookkeeping can look read-heavy — a queue poller
+  # reads constantly, and an idle database shows no enqueues — but they are the
+  # database's working state, not data an application should pin in memory.
+  @infrastructure [~r/^oban_/, ~r/schema_migrations$/]
 
-  defp verdict(ratio, rows, _reads, _writes, min_ratio, max_rows) do
+  defp infrastructure?(table), do: Enum.any?(@infrastructure, &Regex.match?(&1, table))
+
+  defp verdict(_table, _ratio, _rows, 0, 0, _min_ratio, _max_rows), do: :no_traffic
+
+  defp verdict(table, ratio, rows, _reads, _writes, min_ratio, max_rows) do
     cond do
+      infrastructure?(table) -> :infrastructure
       rows > max_rows -> :too_large
       ratio == :infinity -> :strong
       ratio >= min_ratio * 10 -> :strong
@@ -198,12 +207,14 @@ defmodule ActiveMemory.Candidates do
   defp rank(:candidate), do: 1
   defp rank(:too_large), do: 2
   defp rank(:write_heavy), do: 3
-  defp rank(:no_traffic), do: 4
+  defp rank(:infrastructure), do: 4
+  defp rank(:no_traffic), do: 5
 
   defp label(:strong), do: "** strong candidate"
   defp label(:candidate), do: "*  candidate"
   defp label(:too_large), do: "too large to pin in memory"
   defp label(:write_heavy), do: "write heavy"
+  defp label(:infrastructure), do: "infrastructure (queue/migrations)"
   defp label(:no_traffic), do: "no traffic recorded"
 
   defp format_ratio(:infinity), do: "inf"

--- a/lib/candidates.ex
+++ b/lib/candidates.ex
@@ -44,6 +44,7 @@ defmodule ActiveMemory.Candidates do
 
   @default_min_ratio 10
   @default_max_rows 50_000
+  @default_min_reads 100
 
   @postgres_sql """
   SELECT relname,
@@ -94,6 +95,10 @@ defmodule ActiveMemory.Candidates do
       (default #{@default_min_ratio}; ten times that is a strong candidate)
     - `:max_rows` — above this a table is `:too_large` for the in-memory sweet
       spot regardless of its ratio (default #{@default_max_rows})
+    - `:min_reads` — below this many total operations a table's ratio carries no
+      signal (one stray read of an untouched table is an infinite ratio), so it
+      is reported as having too little traffic to judge
+      (default #{@default_min_reads})
 
   Results are sorted candidates first, then by reads.
   """
@@ -101,6 +106,7 @@ defmodule ActiveMemory.Candidates do
   def analyze(rows, opts \\ []) do
     min_ratio = Keyword.get(opts, :min_ratio, @default_min_ratio)
     max_rows = Keyword.get(opts, :max_rows, @default_max_rows)
+    min_reads = Keyword.get(opts, :min_reads, @default_min_reads)
 
     rows
     |> Enum.map(fn [table, row_count, bytes, reads, writes] ->
@@ -117,7 +123,15 @@ defmodule ActiveMemory.Candidates do
         reads: reads,
         writes: writes,
         ratio: ratio,
-        verdict: verdict(to_string(table), ratio, row_count, reads, writes, min_ratio, max_rows)
+        verdict:
+          verdict(
+            to_string(table),
+            ratio,
+            row_count,
+            reads,
+            writes,
+            {min_ratio, max_rows, min_reads}
+          )
       }
     end)
     |> Enum.sort_by(fn %{verdict: verdict, reads: reads} -> {rank(verdict), -reads} end)
@@ -190,11 +204,10 @@ defmodule ActiveMemory.Candidates do
 
   defp infrastructure?(table), do: Enum.any?(@infrastructure, &Regex.match?(&1, table))
 
-  defp verdict(_table, _ratio, _rows, 0, 0, _min_ratio, _max_rows), do: :no_traffic
-
-  defp verdict(table, ratio, rows, _reads, _writes, min_ratio, max_rows) do
+  defp verdict(table, ratio, rows, reads, writes, {min_ratio, max_rows, min_reads}) do
     cond do
       infrastructure?(table) -> :infrastructure
+      reads + writes < min_reads -> :no_traffic
       rows > max_rows -> :too_large
       ratio == :infinity -> :strong
       ratio >= min_ratio * 10 -> :strong
@@ -215,7 +228,7 @@ defmodule ActiveMemory.Candidates do
   defp label(:too_large), do: "too large to pin in memory"
   defp label(:write_heavy), do: "write heavy"
   defp label(:infrastructure), do: "infrastructure (queue/migrations)"
-  defp label(:no_traffic), do: "no traffic recorded"
+  defp label(:no_traffic), do: "not enough traffic to judge"
 
   defp format_ratio(:infinity), do: "inf"
   defp format_ratio(ratio) when ratio >= 100, do: "#{round(ratio)}:1"

--- a/lib/candidates.ex
+++ b/lib/candidates.ex
@@ -103,6 +103,10 @@ defmodule ActiveMemory.Candidates do
 
     rows
     |> Enum.map(fn [table, row_count, bytes, reads, writes] ->
+      row_count = to_int(row_count)
+      bytes = to_int(bytes)
+      reads = to_int(reads)
+      writes = to_int(writes)
       ratio = ratio(reads, writes)
 
       %__MODULE__{
@@ -117,6 +121,13 @@ defmodule ActiveMemory.Candidates do
     end)
     |> Enum.sort_by(fn %{verdict: verdict, reads: reads} -> {rank(verdict), -reads} end)
   end
+
+  # Postgres returns these columns as integers, but MySQL promotes sums of its
+  # unsigned bigint counters to DECIMAL, so MyXQL delivers Decimal structs.
+  defp to_int(%Decimal{} = decimal), do: decimal |> Decimal.round(0) |> Decimal.to_integer()
+  defp to_int(integer) when is_integer(integer), do: integer
+  defp to_int(float) when is_float(float), do: round(float)
+  defp to_int(nil), do: 0
 
   @doc """
   Render analyzed results as a text report.

--- a/lib/candidates.ex
+++ b/lib/candidates.ex
@@ -200,7 +200,7 @@ defmodule ActiveMemory.Candidates do
   # Job queues and migration bookkeeping can look read-heavy — a queue poller
   # reads constantly, and an idle database shows no enqueues — but they are the
   # database's working state, not data an application should pin in memory.
-  @infrastructure [~r/^oban_/, ~r/schema_migrations$/]
+  @infrastructure [~r/^oban_/, ~r/schema_migrations$/, ~r/^ar_internal_metadata$/]
 
   defp infrastructure?(table), do: Enum.any?(@infrastructure, &Regex.match?(&1, table))
 

--- a/lib/mix/tasks/active_memory.candidates.ex
+++ b/lib/mix/tasks/active_memory.candidates.ex
@@ -25,14 +25,18 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
     * `--min-reads` — tables with fewer total operations than this are reported
       as having too little traffic to judge, since a stray read of an untouched
       table would otherwise look infinitely read-heavy (default 100)
+    * `--timeout` — query timeout in milliseconds, for schemas so large the
+      statistics views themselves are slow (default is the repo's own timeout)
 
   ## Safe against production
 
-  The task runs two read-only `SELECT`s against the database's statistics views,
-  and it does **not** start your application — only its configuration is loaded
-  and the one repo you name is started, with a small pool. Nothing else connects:
-  no other repos, no job processors, no endpoints. Use read-only credentials
-  anyway; they cost nothing.
+  The task performs only read-only queries against the database's statistics
+  views — it never touches application tables — and it does **not** start your
+  application: only its configuration is loaded, and the one repo you name is
+  started with a two connection pool. Nothing else connects: no other repos, no
+  job processors, no endpoints. Use read-only credentials anyway; they cost
+  nothing. The expected impact is the connections themselves plus a few
+  statistics queries.
 
   ## Reading the report
 
@@ -60,7 +64,13 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
   def run(args) do
     {opts, _argv, _invalid} =
       OptionParser.parse(args,
-        strict: [repo: :keep, min_ratio: :integer, max_rows: :integer, min_reads: :integer],
+        strict: [
+          repo: :keep,
+          min_ratio: :integer,
+          max_rows: :integer,
+          min_reads: :integer,
+          timeout: :integer
+        ],
         aliases: [r: :repo]
       )
 
@@ -68,16 +78,18 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
     ensure_started(repo)
     adapter = repo.__adapter__()
 
+    query_opts = [log: false] ++ Keyword.take(opts, [:timeout])
+
     case Candidates.sql_for(adapter) do
       {:ok, sql} ->
-        result = repo.query!(sql, [], log: false)
+        result = repo.query!(sql, [], query_opts)
 
         result.rows
         |> Candidates.analyze(Keyword.take(opts, [:min_ratio, :max_rows, :min_reads]))
         |> Candidates.render()
         |> Mix.shell().info()
 
-        Mix.shell().info(stats_window_note(repo, adapter))
+        Mix.shell().info(stats_window_note(repo, adapter, query_opts))
 
       {:error, message} ->
         Mix.raise(message)
@@ -115,11 +127,11 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
   # Cumulative statistics only mean something over a known window, so tell the
   # reader when theirs began. Postgres records a reset time (NULL when the
   # statistics have never been reset); MySQL counters start at server start.
-  defp stats_window_note(repo, Ecto.Adapters.Postgres) do
+  defp stats_window_note(repo, Ecto.Adapters.Postgres, query_opts) do
     case repo.query!(
            "SELECT stats_reset FROM pg_stat_database WHERE datname = current_database()",
            [],
-           log: false
+           query_opts
          ) do
       %{rows: [[%DateTime{} = reset]]} ->
         "Statistics are cumulative since #{DateTime.to_iso8601(reset)}. " <>
@@ -131,7 +143,7 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
     end
   end
 
-  defp stats_window_note(_repo, _adapter) do
+  defp stats_window_note(_repo, _adapter, _query_opts) do
     "Statistics are cumulative since the database server started. " <>
       "Run against production-like traffic for meaningful ratios."
   end

--- a/lib/mix/tasks/active_memory.candidates.ex
+++ b/lib/mix/tasks/active_memory.candidates.ex
@@ -23,6 +23,14 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
     * `--max-rows` — tables above this row count are flagged as too large for the
       in-memory sweet spot (default 50000)
 
+  ## Safe against production
+
+  The task runs two read-only `SELECT`s against the database's statistics views,
+  and it does **not** start your application — only its configuration is loaded
+  and the one repo you name is started, with a small pool. Nothing else connects:
+  no other repos, no job processors, no endpoints. Use read-only credentials
+  anyway; they cost nothing.
+
   ## Reading the report
 
   Statistics are cumulative — since the last statistics reset on PostgreSQL, since
@@ -39,7 +47,11 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
 
   alias ActiveMemory.Candidates
 
-  @requirements ["app.start"]
+  # Deliberately `app.config`, not `app.start`: the application is NOT booted,
+  # only its configuration is loaded and the one repo is started. Pointing this
+  # task at a production database must not also point Oban, background jobs and
+  # every other repo pool at it.
+  @requirements ["app.config"]
 
   @impl Mix.Task
   def run(args) do
@@ -55,7 +67,7 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
 
     case Candidates.sql_for(adapter) do
       {:ok, sql} ->
-        result = repo.query!(sql)
+        result = repo.query!(sql, [], log: false)
 
         result.rows
         |> Candidates.analyze(Keyword.take(opts, [:min_ratio, :max_rows]))
@@ -82,9 +94,14 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
     end
   end
 
-  # `app.start` boots a supervised repo; a repo outside the supervision tree
-  # (scripts, some release setups) still needs starting to be queried.
+  # The application is not started, so the adapter's applications (postgrex or
+  # myxql, db_connection) and the repo itself are started here, with a minimal
+  # pool. `already_started` is tolerated for callers running inside an app.
   defp ensure_started(repo) do
+    # :ecto runs the Repo.Registry every repo registers with on start
+    {:ok, _ecto} = Application.ensure_all_started(:ecto)
+    {:ok, _apps} = repo.__adapter__().ensure_all_started(repo.config(), :temporary)
+
     case repo.start_link(pool_size: 2) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _pid}} -> :ok
@@ -97,7 +114,9 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
   # statistics have never been reset); MySQL counters start at server start.
   defp stats_window_note(repo, Ecto.Adapters.Postgres) do
     case repo.query!(
-           "SELECT stats_reset FROM pg_stat_database WHERE datname = current_database()"
+           "SELECT stats_reset FROM pg_stat_database WHERE datname = current_database()",
+           [],
+           log: false
          ) do
       %{rows: [[%DateTime{} = reset]]} ->
         "Statistics are cumulative since #{DateTime.to_iso8601(reset)}. " <>

--- a/lib/mix/tasks/active_memory.candidates.ex
+++ b/lib/mix/tasks/active_memory.candidates.ex
@@ -1,0 +1,116 @@
+defmodule Mix.Tasks.ActiveMemory.Candidates do
+  @shortdoc "Find database tables that would benefit from ActiveMemory"
+
+  @moduledoc """
+  Reads your database's own table statistics through the application's Ecto repo
+  and reports which tables have the high-read, low-write workload that makes them
+  candidates for an `ActiveMemory.Table`.
+
+      $ mix active_memory.candidates
+      $ mix active_memory.candidates -r MyApp.Repo
+      $ mix active_memory.candidates --min-ratio 25 --max-rows 10000
+
+  The repo comes from `-r`/`--repo`, or from the application's `:ecto_repos`
+  configuration, exactly as the `ecto.*` tasks resolve it. PostgreSQL and
+  MySQL/MariaDB are supported; the statistics sources and what counts as a "read"
+  on each are described in `ActiveMemory.Candidates`.
+
+  ## Options
+
+    * `-r`, `--repo` — the Ecto repo to read statistics through
+    * `--min-ratio` — reads per write to call a table a candidate (default 10;
+      ten times this is a strong candidate)
+    * `--max-rows` — tables above this row count are flagged as too large for the
+      in-memory sweet spot (default 50000)
+
+  ## Reading the report
+
+  Statistics are cumulative — since the last statistics reset on PostgreSQL, since
+  server start on MySQL — so run this against a database that has seen
+  production-like traffic. A development database exercised only by your test
+  suite will tell you nothing useful.
+
+  A candidate is worth confirming by eye: the numbers say "read constantly,
+  written rarely", but only you know whether the table is authoritative data your
+  application could load at boot and serve from memory.
+  """
+
+  use Mix.Task
+
+  alias ActiveMemory.Candidates
+
+  @requirements ["app.start"]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _argv, _invalid} =
+      OptionParser.parse(args,
+        strict: [repo: :keep, min_ratio: :integer, max_rows: :integer],
+        aliases: [r: :repo]
+      )
+
+    repo = resolve_repo(args)
+    ensure_started(repo)
+    adapter = repo.__adapter__()
+
+    case Candidates.sql_for(adapter) do
+      {:ok, sql} ->
+        result = repo.query!(sql)
+
+        result.rows
+        |> Candidates.analyze(Keyword.take(opts, [:min_ratio, :max_rows]))
+        |> Candidates.render()
+        |> Mix.shell().info()
+
+        Mix.shell().info(stats_window_note(repo, adapter))
+
+      {:error, message} ->
+        Mix.raise(message)
+    end
+  end
+
+  defp resolve_repo(args) do
+    case Mix.Ecto.parse_repo(args) do
+      [repo | _rest] ->
+        Mix.Ecto.ensure_repo(repo, args)
+
+      [] ->
+        Mix.raise(
+          "no Ecto repo found. Pass one with -r MyApp.Repo or configure :ecto_repos " <>
+            "for your application."
+        )
+    end
+  end
+
+  # `app.start` boots a supervised repo; a repo outside the supervision tree
+  # (scripts, some release setups) still needs starting to be queried.
+  defp ensure_started(repo) do
+    case repo.start_link(pool_size: 2) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, error} -> Mix.raise("could not start #{inspect(repo)}: #{inspect(error)}")
+    end
+  end
+
+  # Cumulative statistics only mean something over a known window, so tell the
+  # reader when theirs began. Postgres records a reset time (NULL when the
+  # statistics have never been reset); MySQL counters start at server start.
+  defp stats_window_note(repo, Ecto.Adapters.Postgres) do
+    case repo.query!(
+           "SELECT stats_reset FROM pg_stat_database WHERE datname = current_database()"
+         ) do
+      %{rows: [[%DateTime{} = reset]]} ->
+        "Statistics are cumulative since #{DateTime.to_iso8601(reset)}. " <>
+          "Run against production-like traffic for meaningful ratios."
+
+      _never_reset ->
+        "Statistics are cumulative since this database's statistics began. " <>
+          "Run against production-like traffic for meaningful ratios."
+    end
+  end
+
+  defp stats_window_note(_repo, _adapter) do
+    "Statistics are cumulative since the database server started. " <>
+      "Run against production-like traffic for meaningful ratios."
+  end
+end

--- a/lib/mix/tasks/active_memory.candidates.ex
+++ b/lib/mix/tasks/active_memory.candidates.ex
@@ -22,6 +22,9 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
       ten times this is a strong candidate)
     * `--max-rows` — tables above this row count are flagged as too large for the
       in-memory sweet spot (default 50000)
+    * `--min-reads` — tables with fewer total operations than this are reported
+      as having too little traffic to judge, since a stray read of an untouched
+      table would otherwise look infinitely read-heavy (default 100)
 
   ## Safe against production
 
@@ -57,7 +60,7 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
   def run(args) do
     {opts, _argv, _invalid} =
       OptionParser.parse(args,
-        strict: [repo: :keep, min_ratio: :integer, max_rows: :integer],
+        strict: [repo: :keep, min_ratio: :integer, max_rows: :integer, min_reads: :integer],
         aliases: [r: :repo]
       )
 
@@ -70,7 +73,7 @@ defmodule Mix.Tasks.ActiveMemory.Candidates do
         result = repo.query!(sql, [], log: false)
 
         result.rows
-        |> Candidates.analyze(Keyword.take(opts, [:min_ratio, :max_rows]))
+        |> Candidates.analyze(Keyword.take(opts, [:min_ratio, :max_rows, :min_reads]))
         |> Candidates.render()
         |> Mix.shell().info()
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ActiveMemory.MixProject do
   @github "https://github.com/SullysMustyRuby/active_memory"
   @license "MIT"
   @name "ActiveMemory"
-  @version "0.8.0"
+  @version "0.8.1"
 
   def project do
     [

--- a/test/candidates_test.exs
+++ b/test/candidates_test.exs
@@ -48,6 +48,17 @@ defmodule ActiveMemory.CandidatesTest do
                Candidates.analyze([["archived", 10, 8192, 0, 0]])
     end
 
+    test "a stray read of an untouched table carries no signal" do
+      # From a real dev database: one incidental read gives an infinite ratio,
+      # which would have called 35 idle tables strong candidates.
+      assert [%{verdict: :no_traffic}] =
+               Candidates.analyze([["b4b_rentals", 0, 8192, 1, 0]])
+
+      # tunable: with the floor lowered, the same table classifies on its ratio
+      assert [%{verdict: :strong}] =
+               Candidates.analyze([["b4b_rentals", 0, 8192, 1, 0]], min_reads: 1)
+    end
+
     test "zero reads with some writes is write heavy, not a divide error" do
       assert [%{verdict: :write_heavy, ratio: +0.0}] =
                Candidates.analyze([["audit_log", 100, 8192, 0, 500]])
@@ -94,7 +105,7 @@ defmodule ActiveMemory.CandidatesTest do
     test "sorts candidates first, then by reads" do
       rows = [
         @events,
-        ["countries", 249, 65_536, 90, 0],
+        ["countries", 249, 65_536, 900, 0],
         @plans,
         ["stale", 5, 8192, 0, 0]
       ]

--- a/test/candidates_test.exs
+++ b/test/candidates_test.exs
@@ -53,6 +53,32 @@ defmodule ActiveMemory.CandidatesTest do
                Candidates.analyze([["audit_log", 100, 8192, 0, 500]])
     end
 
+    test "normalizes the Decimal values MyXQL returns for MySQL's counters" do
+      # MySQL promotes sums of BIGINT UNSIGNED counters to DECIMAL, so every
+      # numeric column can arrive as a Decimal rather than an integer. Shapes
+      # taken from a run against a real Aurora MySQL staging database.
+      rows = [
+        [
+          "accounts",
+          Decimal.new(120),
+          Decimal.new("221184"),
+          Decimal.new("50000"),
+          Decimal.new("3")
+        ],
+        ["events", Decimal.new(0), Decimal.new("0"), Decimal.new("0"), Decimal.new("0")]
+      ]
+
+      assert [accounts, events] = Candidates.analyze(rows)
+
+      assert %{verdict: :strong, rows: 120, bytes: 221_184, reads: 50_000, writes: 3} = accounts
+      assert %{verdict: :no_traffic} = events
+
+      # rendering must not crash on the normalized values
+      report = Candidates.render([accounts, events])
+      assert report =~ "50,000"
+      assert report =~ "216 KB"
+    end
+
     test "sorts candidates first, then by reads" do
       rows = [
         @events,

--- a/test/candidates_test.exs
+++ b/test/candidates_test.exs
@@ -1,0 +1,109 @@
+defmodule ActiveMemory.CandidatesTest do
+  use ExUnit.Case, async: true
+
+  alias ActiveMemory.Candidates
+
+  # The `plans`/`events` rows are verbatim from pg_stat_user_tables on a real
+  # PostgreSQL 17 database after a simulated read-heavy/write-heavy workload.
+  @plans ["plans", 20, 32_768, 501, 20]
+  @events ["events", 2000, 278_528, 3, 3000]
+
+  describe "analyze/2" do
+    test "classifies a read-heavy table as a candidate and a write-heavy one as not" do
+      assert [plans, events] = Candidates.analyze([@events, @plans])
+
+      assert %{table: "plans", verdict: :candidate} = plans
+      assert_in_delta plans.ratio, 25.05, 0.001
+
+      assert %{table: "events", verdict: :write_heavy} = events
+    end
+
+    test "a table with reads and zero writes is a strong candidate with infinite ratio" do
+      assert [%{verdict: :strong, ratio: :infinity}] =
+               Candidates.analyze([["countries", 249, 65_536, 9000, 0]])
+    end
+
+    test "a ratio of at least ten times min_ratio is strong" do
+      assert [%{verdict: :strong}] =
+               Candidates.analyze([["flags", 12, 8192, 1000, 5]])
+    end
+
+    test "a large table is flagged regardless of its ratio" do
+      assert [%{verdict: :too_large}] =
+               Candidates.analyze([["users", 2_000_000, 1_073_741_824, 9_000_000, 10]])
+    end
+
+    test "max_rows and min_ratio are tunable" do
+      assert [%{verdict: :strong}] =
+               Candidates.analyze([["users", 2_000_000, 0, 9_000_000, 10]],
+                 max_rows: 5_000_000,
+                 min_ratio: 100
+               )
+
+      assert [%{verdict: :write_heavy}] = Candidates.analyze([@plans], min_ratio: 50)
+    end
+
+    test "a table with no traffic at all is reported as such, not as a candidate" do
+      assert [%{verdict: :no_traffic}] =
+               Candidates.analyze([["archived", 10, 8192, 0, 0]])
+    end
+
+    test "zero reads with some writes is write heavy, not a divide error" do
+      assert [%{verdict: :write_heavy, ratio: +0.0}] =
+               Candidates.analyze([["audit_log", 100, 8192, 0, 500]])
+    end
+
+    test "sorts candidates first, then by reads" do
+      rows = [
+        @events,
+        ["countries", 249, 65_536, 90, 0],
+        @plans,
+        ["stale", 5, 8192, 0, 0]
+      ]
+
+      assert ["countries", "plans", "events", "stale"] =
+               Candidates.analyze(rows) |> Enum.map(& &1.table)
+    end
+  end
+
+  describe "render/1" do
+    test "renders a table with a summary line" do
+      report = Candidates.analyze([@plans, @events]) |> Candidates.render()
+
+      assert report =~ "plans"
+      assert report =~ "candidate"
+      assert report =~ "25.1:1"
+      assert report =~ "write heavy"
+      assert report =~ "1 candidate for ActiveMemory."
+    end
+
+    test "formats large numbers, sizes, and infinite ratios readably" do
+      report =
+        Candidates.analyze([["countries", 249, 1_262_485_504, 1_234_567, 0]],
+          max_rows: 500
+        )
+        |> Candidates.render()
+
+      assert report =~ "1,234,567"
+      assert report =~ "1.2 GB"
+      assert report =~ "inf"
+    end
+
+    test "an empty result explains itself" do
+      assert Candidates.render([]) =~ "No user tables"
+    end
+  end
+
+  describe "sql_for/1" do
+    test "supports postgres and mysql, rejects others by name" do
+      assert {:ok, sql} = Candidates.sql_for(Ecto.Adapters.Postgres)
+      assert sql =~ "pg_stat_user_tables"
+
+      assert {:ok, sql} = Candidates.sql_for(Ecto.Adapters.MyXQL)
+      assert sql =~ "performance_schema.table_io_waits_summary_by_table"
+
+      assert {:error, message} = Candidates.sql_for(Ecto.Adapters.SQLite3)
+      assert message =~ "SQLite3"
+    end
+  end
+end

--- a/test/candidates_test.exs
+++ b/test/candidates_test.exs
@@ -79,6 +79,18 @@ defmodule ActiveMemory.CandidatesTest do
       assert report =~ "216 KB"
     end
 
+    test "queue and migration tables are infrastructure, not candidates" do
+      # From a real staging run: an idle Oban polls its queue constantly and
+      # enqueues nothing, which looks like a strong candidate by the numbers.
+      rows = [
+        ["oban_jobs", 0, 32_768, 31_329, 0],
+        ["oban_peers", 1, 16_384, 2209, 1485],
+        ["phoenix_schema_migrations", 7, 16_384, 35, 7]
+      ]
+
+      assert Enum.all?(Candidates.analyze(rows), &(&1.verdict == :infrastructure))
+    end
+
     test "sorts candidates first, then by reads" do
       rows = [
         @events,

--- a/test/candidates_test.exs
+++ b/test/candidates_test.exs
@@ -96,7 +96,8 @@ defmodule ActiveMemory.CandidatesTest do
       rows = [
         ["oban_jobs", 0, 32_768, 31_329, 0],
         ["oban_peers", 1, 16_384, 2209, 1485],
-        ["phoenix_schema_migrations", 7, 16_384, 35, 7]
+        ["phoenix_schema_migrations", 7, 16_384, 35, 7],
+        ["ar_internal_metadata", 0, 16_384, 200, 1]
       ]
 
       assert Enum.all?(Candidates.analyze(rows), &(&1.verdict == :infrastructure))


### PR DESCRIPTION
The database burden story starts with a question every reader asks next: which of my tables? The database already keeps the answer, so this task reads it through the application's own Ecto repo — no new dependencies — and reports each table's read/write ratio, row count and size, flagging the high-read, low-write tables that fit an ActiveMemory table.

PostgreSQL statistics come from pg_stat_user_tables (reads are scans, so each query touching the table counts once; writes are rows changed). MySQL/MariaDB comes from
performance_schema.table_io_waits_summary_by_table joined to information_schema for sizes (reads and writes are row operations). The units differ between databases and ratios are only comparable within one, which the docs say plainly. Verdict thresholds are tunable with --min-ratio and --max-rows, tables above the row cap are flagged too large regardless of ratio, and the report names the statistics window since cumulative counters over an unknown period describe nothing.

The analysis is pure and unit tested with rows captured verbatim from pg_stat_user_tables on PostgreSQL 17 after a simulated read-heavy and write-heavy workload; the task itself was run end to end against that database through an Ecto repo, including the never-reset NULL stats_reset path.