### PR TITLE
Fix catch-all handle_info shadowing user-defined clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to ActiveMemory are documented here. Versions follow
 [Semantic Versioning](https://semver.org); while the package is pre-1.0 a minor
 bump may carry a behavior change, and those are called out below.
 
+## 0.8.2
+
+### Fixed
+
+- `use ActiveMemory.Store` and `use ActiveMemory.ActiveRepo` no longer swallow
+  the using module's own `handle_info` clauses. The injected unknown-message
+  catch-all is now added via `@before_compile` — after user-defined clauses —
+  instead of at the `use` site above them, where it made every custom clause
+  unreachable: timer ticks and monitor messages sent to a store were silently
+  discarded, and Elixir 1.19's type checker flags the dead clauses as
+  redundant. Library-owned messages (`:sweep`, `:"ETS-TRANSFER"`) keep
+  priority; unknown messages still no-op.
+
 ## 0.8.1
 
 ### Added

--- a/lib/active_repo.ex
+++ b/lib/active_repo.ex
@@ -116,6 +116,16 @@ defmodule ActiveMemory.ActiveRepo do
 
   @default_sweep_interval :timer.seconds(60)
 
+  @doc false
+  defmacro __before_compile__(_env) do
+    # The catch-all must compile after any handle_info clauses the using module
+    # defines. Injected at the `use` site it would sit above them and swallow
+    # every custom message (timer ticks, monitors) without a trace.
+    quote generated: true do
+      def handle_info(_message, state), do: {:noreply, state}
+    end
+  end
+
   defmacro __using__(opts) do
     quote do
       use GenServer
@@ -275,7 +285,9 @@ defmodule ActiveMemory.ActiveRepo do
         {:noreply, state}
       end
 
-      def handle_info(_message, state), do: {:noreply, state}
+      # The unknown-message catch-all is injected via __before_compile__ so it
+      # lands after any handle_info clauses the using module defines.
+      @before_compile ActiveMemory.ActiveRepo
 
       # Only the clause matching the compile-time option is generated so the
       # Elixir 1.19+ type checker never sees an unreachable clause.

--- a/lib/store.ex
+++ b/lib/store.ex
@@ -195,6 +195,16 @@ defmodule ActiveMemory.Store do
 
   @default_sweep_interval :timer.seconds(60)
 
+  @doc false
+  defmacro __before_compile__(_env) do
+    # The catch-all must compile after any handle_info clauses the using module
+    # defines. Injected at the `use` site it would sit above them and swallow
+    # every custom message (timer ticks, monitors) without a trace.
+    quote generated: true do
+      def handle_info(_message, state), do: {:noreply, state}
+    end
+  end
+
   defmacro __using__(opts) do
     quote do
       import unquote(__MODULE__)
@@ -308,7 +318,9 @@ defmodule ActiveMemory.Store do
         {:noreply, state}
       end
 
-      def handle_info(_message, state), do: {:noreply, state}
+      # The unknown-message catch-all is injected via __before_compile__ so it
+      # lands after any handle_info clauses the using module defines.
+      @before_compile ActiveMemory.Store
 
       # A recovered table already holds its data, so seeding is skipped to avoid
       # duplicating or clobbering the surviving records.

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ActiveMemory.MixProject do
   @github "https://github.com/SullysMustyRuby/active_memory"
   @license "MIT"
   @name "ActiveMemory"
-  @version "0.8.1"
+  @version "0.8.2"
 
   def project do
     [

--- a/test/handle_info_ordering_test.exs
+++ b/test/handle_info_ordering_test.exs
@@ -1,0 +1,44 @@
+defmodule ActiveMemory.HandleInfoOrderingTest do
+  # Regression: the `use ActiveMemory.Store` catch-all handle_info used to be
+  # injected above the using module's own handle_info clauses, so custom
+  # messages (timer ticks, monitors) were silently swallowed and the clauses
+  # were dead code. The catch-all now lands via @before_compile, after them.
+  use ExUnit.Case
+
+  defmodule PingTable do
+    use ActiveMemory.Table, type: :ets
+
+    attributes do
+      field(:name)
+    end
+  end
+
+  defmodule PingStore do
+    use ActiveMemory.Store, table: PingTable
+
+    def handle_info({:ping, from}, state) do
+      send(from, :pong)
+      {:noreply, state}
+    end
+  end
+
+  describe "user-defined handle_info clauses" do
+    test "receive their messages instead of being swallowed by the catch-all" do
+      pid = start_supervised!(PingStore)
+
+      send(pid, {:ping, self()})
+
+      assert_receive :pong, 1_000
+    end
+
+    test "unknown messages still fall through to the library catch-all" do
+      pid = start_supervised!(PingStore)
+
+      send(pid, :message_no_clause_handles)
+
+      # The store must survive the unknown message and stay responsive.
+      assert %{} = PingStore.state()
+      assert Process.alive?(pid)
+    end
+  end
+end


### PR DESCRIPTION
Store and ActiveRepo injected 'def handle_info(_message, state)' at the use site, above any handle_info clauses the using module defines - so custom timer and monitor messages were silently swallowed and the clauses were dead code (Elixir 1.19's type checker flags them as redundant; found via CoreServer, where six servers' periodic cleanup never ran). The catch-all now lands via @before_compile, after user clauses. Library-owned messages (:sweep, ETS-TRANSFER) keep priority.

Regression test verifies a user clause receives its message (fails on the old ordering) and that unknown messages still no-op.